### PR TITLE
Make Track API LocationDetail schema's locationType attribute optional

### DIFF
--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -50,6 +50,14 @@
                 "action": "replace",
                 "path": "paths./track/v1/tcn.post.operationId",
                 "value": "Track by TCN"
+            },
+            {
+                "comment": "Remove the locationType attribute from the required list. See https://github.com/ShipStream/fedex-rest-php-sdk/issues/3",
+                "action": "replace",
+                "path": "components.schemas.LocationDetail.required",
+                "value": [
+                    "locationContactAndAddress"
+                ]
             }
         ]
     }

--- a/resources/models/track/v1.json
+++ b/resources/models/track/v1.json
@@ -3489,8 +3489,7 @@
                 },
                 "description": "Location details for the fedex facility.",
                 "required": [
-                    "locationContactAndAddress",
-                    "locationType"
+                    "locationContactAndAddress"
                 ]
             },
             "ContactAndAddress": {

--- a/src/Api/TrackV1/Dto/LocationDetail.php
+++ b/src/Api/TrackV1/Dto/LocationDetail.php
@@ -16,12 +16,12 @@ final class LocationDetail extends Dto
 {
     /**
      * @param  ContactAndAddress2  $locationContactAndAddress  Location Contact And Address.
-     * @param  string  $locationType  This field holds FedEx Location Type. If  Location Type not available we will get empty value.
      * @param  ?string  $locationId  Location Identification for facilities identified by an alpha numeric location code. Passing Location Id of the Hold at Location (HAL) address is strongly recommended to ensure packages are delivered to the correct address.<br> Example: SEA
+     * @param  ?string  $locationType  This field holds FedEx Location Type. If  Location Type not available we will get empty value.
      */
     public function __construct(
         public ContactAndAddress2 $locationContactAndAddress,
-        public string $locationType,
         public ?string $locationId = null,
+        public ?string $locationType = null,
     ) {}
 }


### PR DESCRIPTION
Fixes #3. This is a temporary fix until we figure out why our internally generated Track V1 model is different than FedEx's (see [this comment](https://github.com/ShipStream/fedex-rest-php-sdk/issues/3#issuecomment-2483814769)).