### PR TITLE
Saloon v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     ],
     "license": "Apache-2.0",
     "require": {
-        "saloonphp/saloon": "^3.8",
-        "saloonphp/rate-limit-plugin": "^2.1"
+        "saloonphp/saloon": "^4.0",
+        "saloonphp/rate-limit-plugin": "^2.5"
     },
     "require-dev": {
-        "highsidelabs/saloon-sdk-generator": "^2.1",
+        "highsidelabs/saloon-sdk-generator": "^2.1.8",
         "psy/psysh": "^0.12.3",
         "symfony/console": "^7.0",
         "phpcompatibility/php-compatibility": "dev-develop",

--- a/src/Auth/TokenSerializer.php
+++ b/src/Auth/TokenSerializer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShipStream\FedEx\Auth;
+
+use DateTimeImmutable;
+use Saloon\Http\Auth\AccessTokenAuthenticator;
+use Throwable;
+
+/**
+ * Drop-in replacement for the AccessTokenAuthenticator::serialize()/unserialize()
+ * methods that were removed in Saloon v4.
+ */
+final class TokenSerializer
+{
+    public static function serialize(AccessTokenAuthenticator $authenticator): string
+    {
+        return serialize($authenticator);
+    }
+
+    public static function unserialize(string $data): ?AccessTokenAuthenticator
+    {
+        try {
+            $token = @unserialize($data, [
+                'allowed_classes' => [
+                    AccessTokenAuthenticator::class,
+                    DateTimeImmutable::class,
+                ],
+            ]);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $token instanceof AccessTokenAuthenticator ? $token : null;
+    }
+}

--- a/tests/TokenSerializerTest.php
+++ b/tests/TokenSerializerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Saloon\Http\Auth\AccessTokenAuthenticator;
+use ShipStream\FedEx\Auth\TokenSerializer;
+
+final class TokenSerializerTest extends TestCase
+{
+    public function testRoundTripsAnAuthenticator(): void
+    {
+        $authenticator = new AccessTokenAuthenticator(
+            accessToken: 'access-123',
+            refreshToken: 'refresh-456',
+            expiresAt: new DateTimeImmutable('+1 hour'),
+        );
+
+        $serialized = TokenSerializer::serialize($authenticator);
+        $restored = TokenSerializer::unserialize($serialized);
+
+        $this->assertEquals($authenticator, $restored);
+    }
+
+    public function testRoundTripsAnAuthenticatorWithNullRefreshAndExpiry(): void
+    {
+        $authenticator = new AccessTokenAuthenticator(accessToken: 'access-123');
+
+        $serialized = TokenSerializer::serialize($authenticator);
+        $restored = TokenSerializer::unserialize($serialized);
+
+        $this->assertEquals($authenticator, $restored);
+    }
+
+    public function testReturnsNullForGarbageInput(): void
+    {
+        $this->assertNull(TokenSerializer::unserialize('not-a-serialized-string'));
+        $this->assertNull(TokenSerializer::unserialize(''));
+    }
+
+    public function testReturnsNullForNonAuthenticatorObject(): void
+    {
+        $serialized = serialize(new DateTimeImmutable);
+
+        $this->assertNull(TokenSerializer::unserialize($serialized));
+    }
+}


### PR DESCRIPTION
Updated saloonphp/saloon to v4 to resolve https://github.com/ShipStream/fedex-rest-php-sdk/issues/9. 

Added a TokenSerializer class as a drop in replacement for the serialization that was removed from saloon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Saloon to v4.0 and related dependencies (rate-limit-plugin, SDK generator)

* **New Features**
  * Added token serialization and deserialization utilities for authentication tokens

* **Tests**
  * Added comprehensive test coverage for token serialization functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->